### PR TITLE
fix: `request.end(callback)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,14 @@ export default {
       const requestBodyChunks = [];
       for (const method of ["write", "end"]) {
         const originalMethod = interceptedRequest[method];
-        interceptedRequest[method] = function (chunk) {
-          if (chunk) requestBodyChunks.push(Buffer.from(chunk));
-          return originalMethod.call(this, chunk);
+        interceptedRequest[method] = function (chunk, encoding, callback) {
+          // chunk argument may be set to the callback function, see
+          // https://github.com/nodejs/node/blob/9e1a08057a0cd803d0878ed4b87774b5f84d6f0a/lib/_http_outgoing.js#L834-L841
+          if (chunk && typeof chunk !== "function") {
+            requestBodyChunks.push(Buffer.from(chunk));
+          }
+
+          return originalMethod.call(this, chunk, encoding, callback);
         };
       }
 

--- a/test.js
+++ b/test.js
@@ -74,57 +74,28 @@ test("happy path", () => {
   request.end();
 });
 
-test("Using request.end", () => {
+test("request.end(text)", () => {
   const server = http.createServer(async (_request, response) => {
-    response.setHeader("x-my-response-header", 2);
-    response.end("World!");
+    response.end();
   });
   const { port } = server.listen().address();
 
   HttpRecorder.enable();
-  HttpRecorder.on(
-    "record",
-    async ({ request, response, requestBody, responseBody }) => {
-      const { method, protocol, host, path } = request;
-      const requestHeaders = { ...request.getHeaders() };
-
-      try {
-        assert.equal(method, "POST");
-        assert.equal(protocol, "http:");
-        assert.equal(host, "localhost");
-        assert.equal(path, "/path");
-        assert.equal(requestHeaders, {
-          host: "localhost:" + port,
-          "x-my-request-header": "1",
-        });
-        assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
-
-        const {
-          statusCode,
-          statusMessage,
-          headers: responseHeaders,
-        } = response;
-
-        assert.equal(statusCode, 200);
-        assert.equal(statusMessage, "OK");
-        assert.equal(responseHeaders["x-my-response-header"], "2");
-        assert.equal(Buffer.concat(responseBody).toString(), "World!");
-      } catch (error) {
-        if (error.code !== "ERR_ASSERTION") throw error;
-        console.log(error.details);
-        console.log("expected:", error.expects);
-        console.log("actual:", error.actual);
-      }
+  HttpRecorder.on("record", async ({ requestBody, responseBody }) => {
+    try {
+      assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
+    } catch (error) {
+      if (error.code !== "ERR_ASSERTION") throw error;
+      console.log(error.details);
+      console.log("expected:", error.expects);
+      console.log("actual:", error.actual);
     }
-  );
+  });
 
   const request = http.request(
     `http://localhost:${port}/path`,
     {
       method: "post",
-      headers: {
-        "x-my-request-header": "1",
-      },
     },
     () => server.close()
   );


### PR DESCRIPTION
closes #2
