### PR TITLE
fix: handle `request.write(data, callback)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,12 @@ export default {
         interceptedRequest[method] = function (chunk, encoding, callback) {
           // chunk argument may be set to the callback function, see
           // https://github.com/nodejs/node/blob/9e1a08057a0cd803d0878ed4b87774b5f84d6f0a/lib/_http_outgoing.js#L834-L841
+          if (typeof encoding === "function") {
+            callback = encoding;
+            encoding = null;
+          }
           if (chunk && typeof chunk !== "function") {
-            requestBodyChunks.push(Buffer.from(chunk, encoding));
+            requestBodyChunks.push(Buffer.from(chunk, encoding || "utf8"));
           }
 
           return originalMethod.call(this, chunk, encoding, callback);


### PR DESCRIPTION
closes #17
