### PR TITLE
rename `.enable()` to `.start()` and `.disable()` to `.stop()` as it works better with a "recorder"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import http from "node:http";
 import httpRecorder from "@gr2m/http-recorder";
 
 httpRecorder.start();
-httpRecorder.on(
+httpRecorder.addListener(
   "record",
   async ({ request, response, requestBody, responseBody }) => {
     const { method, protocol, host, path } = request;
@@ -63,7 +63,7 @@ Hooks into the request life cycle and emits `record` events for each request sen
 
 Removes the hooks. No `record` events will be emitted.
 
-### `httpRecorder.on("record", listener)`
+### `httpRecorder.addListener("record", listener)`
 
 Subscribe to a `record` event. The `listener` callback is called with an options object
 
@@ -72,7 +72,7 @@ Subscribe to a `record` event. The `listener` callback is called with an options
 - `options.requestBody`: An array of Buffer chunks representing the request body
 - `options.responseBody`: An array of Buffer chunks representing the response body
 
-### `httpRecorder.off("record", listener)`
+### `httpRecorder.removeListener("record", listener)`
 
 Remove a `record` event listener.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install @gr2m/http-recorder
 import http from "node:http";
 import httpRecorder from "@gr2m/http-recorder";
 
-httpRecorder.enable();
+httpRecorder.start();
 httpRecorder.on(
   "record",
   async ({ request, response, requestBody, responseBody }) => {
@@ -55,11 +55,11 @@ request.end();
 
 `httpRecorder` is a singleton API.
 
-### `httpRecorder.enable()`
+### `httpRecorder.start()`
 
 Hooks into the request life cycle and emits `record` events for each request sent through the `http` or `https` modules.
 
-### `httpRecorder.disable()`
+### `httpRecorder.stop()`
 
 Removes the hooks. No `record` events will be emitted.
 
@@ -82,13 +82,13 @@ Removes all `record` event listeners.
 
 ## How it works
 
-When enabled, `httpRecorder` hooks itself into [the `http.ClientRequest.prototype.onSocket` method](https://github.com/nodejs/node/blob/cf6996458b82ec0bdf97209bce380e1483c349fb/lib/_http_client.js#L778-L782) which is conveniently called synchronously in [the `http.ClientRequest` constructor](https://nodejs.org/api/http.html#class-httpclientrequest).
+Once started, `httpRecorder` hooks itself into [the `http.ClientRequest.prototype.onSocket` method](https://github.com/nodejs/node/blob/cf6996458b82ec0bdf97209bce380e1483c349fb/lib/_http_client.js#L778-L782) which is conveniently called synchronously in [the `http.ClientRequest` constructor](https://nodejs.org/api/http.html#class-httpclientrequest).
 
 When a request is intercepted, we
 
-1. hook into [the `request.write` method](https://github.com/nodejs/node/blob/cf6996458b82ec0bdf97209bce380e1483c349fb/lib/_http_outgoing.js#L701-L711) in order to clone the request body
+1. hook into [the `request.write` method](https://github.com/nodejs/node/blob/cf6996458b82ec0bdf97209bce380e1483c349fb/lib/_http_outgoing.js#L701-L711) and [the `request.end` method](https://github.com/nodejs/node/blob/cf6996458b82ec0bdf97209bce380e1483c349fb/lib/_http_outgoing.js#L833-L906) in order to clone the request body
 2. subscribe to [the `response` event](https://nodejs.org/api/http.html#event-response)
-3. hook into the `response.emit` method in order to read the response body without consuming it
+3. hook into the `response.emit` method in order to clone the response body without consuming it
 
 and then emit a `record` event with the `request`, `response`, `requestBody` and `responseBody` options.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import http from "http";
 
 declare const httpRecorder: {
-  enable: () => typeof httpRecorder;
-  disable: () => typeof httpRecorder;
+  start: () => typeof httpRecorder;
+  stop: () => typeof httpRecorder;
   on: (event: "record", listener: RecordHandler) => typeof httpRecorder;
   off: (event: "record", listener: RecordHandler) => typeof httpRecorder;
   removeAllListeners: () => typeof httpRecorder;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,14 @@ import http from "http";
 declare const httpRecorder: {
   start: () => typeof httpRecorder;
   stop: () => typeof httpRecorder;
-  on: (event: "record", listener: RecordHandler) => typeof httpRecorder;
-  off: (event: "record", listener: RecordHandler) => typeof httpRecorder;
+  addListener: (
+    event: "record",
+    listener: RecordHandler
+  ) => typeof httpRecorder;
+  removeListener: (
+    event: "record",
+    listener: RecordHandler
+  ) => typeof httpRecorder;
   removeAllListeners: () => typeof httpRecorder;
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,8 +8,8 @@ export function smokeTest() {
 }
 
 export function API() {
-  expectType<typeof httpRecorder>(httpRecorder.enable());
-  expectType<typeof httpRecorder>(httpRecorder.disable());
+  expectType<typeof httpRecorder>(httpRecorder.start());
+  expectType<typeof httpRecorder>(httpRecorder.stop());
   expectType<typeof httpRecorder>(httpRecorder.on("record", () => {}));
   expectType<typeof httpRecorder>(httpRecorder.off("record", () => {}));
   expectType<typeof httpRecorder>(httpRecorder.removeAllListeners());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,16 +10,18 @@ export function smokeTest() {
 export function API() {
   expectType<typeof httpRecorder>(httpRecorder.start());
   expectType<typeof httpRecorder>(httpRecorder.stop());
-  expectType<typeof httpRecorder>(httpRecorder.on("record", () => {}));
-  expectType<typeof httpRecorder>(httpRecorder.off("record", () => {}));
+  expectType<typeof httpRecorder>(httpRecorder.addListener("record", () => {}));
+  expectType<typeof httpRecorder>(
+    httpRecorder.removeListener("record", () => {})
+  );
   expectType<typeof httpRecorder>(httpRecorder.removeAllListeners());
 
   // @ts-expect-error - only "record" is supported
-  httpRecorder.on("not-record", () => {});
+  httpRecorder.addListener("not-record", () => {});
 }
 
 export function recordHandler() {
-  httpRecorder.on("record", (options) => {
+  httpRecorder.addListener("record", (options) => {
     expectType<http.ClientRequest>(options.request);
     expectType<http.IncomingMessage>(options.response);
     expectType<Buffer[]>(options.requestBody);

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -23,7 +23,7 @@ export default class Recorder extends EventEmitter {
     return EventEmitter.prototype.removeAllListeners.call(this, "record");
   }
 
-  enable() {
+  start() {
     if (isRecording) return;
     isRecording = true;
 
@@ -45,7 +45,7 @@ export default class Recorder extends EventEmitter {
     return this;
   }
 
-  disable() {
+  stop() {
     isRecording = false;
     return this;
   }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -16,7 +16,7 @@ function getFlowControl() {
 }
 
 test.before.each(() => {
-  httpRecorder.disable();
+  httpRecorder.stop();
   httpRecorder.removeAllListeners();
 });
 
@@ -24,12 +24,12 @@ test("smoke", () => {
   assert.ok(httpRecorder);
 });
 
-test("Calling .enable() multiple times is a no-op", () => {
-  httpRecorder.enable();
-  httpRecorder.enable();
+test("Calling .start() multiple times is a no-op", () => {
+  httpRecorder.start();
+  httpRecorder.start();
 });
 
-test("Does not emit record event when not enabled", () => {
+test("Does not emit record event when not started", () => {
   const flowControl = getFlowControl();
 
   httpRecorder.on("record", () => {
@@ -56,7 +56,7 @@ test("Does not emit record event when not enabled", () => {
 test("Does not emit record event handler removed", () => {
   const flowControl = getFlowControl();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   const callback = () => {
     server.close();
     reject(new Error("Should not have been called"));
@@ -98,18 +98,18 @@ test(".off() throws for unknown event", () => {
   }
 });
 
-test(".disable() does not revert other patches", async () => {
+test(".stop() does not revert other patches", async () => {
   const hookControl = getFlowControl();
   const requestControl = getFlowControl();
 
-  httpRecorder.enable();
+  httpRecorder.start();
 
   const origOnSocket = http.ClientRequest.prototype.onSocket;
   http.ClientRequest.prototype.onSocket = function (socket) {
     hookControl.resolve();
     return origOnSocket.call(this, socket);
   };
-  httpRecorder.disable();
+  httpRecorder.stop();
 
   const server = http.createServer((_request, response) => {
     response.end("ok");

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -32,7 +32,7 @@ test("Calling .start() multiple times is a no-op", () => {
 test("Does not emit record event when not started", () => {
   const flowControl = getFlowControl();
 
-  httpRecorder.on("record", () => {
+  httpRecorder.addListener("record", () => {
     server.close();
     flowControl.reject(new Error("Should not have been called"));
   });
@@ -61,8 +61,8 @@ test("Does not emit record event handler removed", () => {
     server.close();
     reject(new Error("Should not have been called"));
   };
-  httpRecorder.on("record", callback);
-  httpRecorder.off("record", callback);
+  httpRecorder.addListener("record", callback);
+  httpRecorder.removeListener("record", callback);
 
   const server = http.createServer((_request, response) => {
     response.end();

--- a/test/record-test.js
+++ b/test/record-test.js
@@ -36,7 +36,7 @@ test("happy path", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on(
+  httpRecorder.addListener(
     "record",
     async ({ request, response, requestBody, responseBody }) => {
       const { method, protocol, host, path } = request;
@@ -103,7 +103,7 @@ test("emits 'record' event", async () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", flowControl.resolve);
+  httpRecorder.addListener("record", flowControl.resolve);
 
   const request = http.request(`http://localhost:${port}`, (response) => {
     response.on("close", () => server.close());
@@ -124,7 +124,7 @@ test("request.write() with base64 encoding", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ requestBody }) => {
+  httpRecorder.addListener("record", async ({ requestBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
       flowControl.resolve();
@@ -161,7 +161,7 @@ test("request.write(data, callback)", async () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ requestBody }) => {
+  httpRecorder.addListener("record", async ({ requestBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
       recordDataControl.resolve();
@@ -200,7 +200,7 @@ test("request.end(text)", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ requestBody, responseBody }) => {
+  httpRecorder.addListener("record", async ({ requestBody, responseBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
       flowControl.resolve();
@@ -235,7 +235,7 @@ test("request.end(callback)", async () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ requestBody, responseBody }) => {
+  httpRecorder.addListener("record", async ({ requestBody, responseBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
       recordControl.resolve();
@@ -277,7 +277,7 @@ test("delayed response read", async () => {
 
   httpRecorder.start();
   let retrievedRecordData = false;
-  httpRecorder.on("record", async ({ responseBody }) => {
+  httpRecorder.addListener("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello!");
       retrievedRecordData = true;
@@ -332,7 +332,7 @@ test("response.end(text)", async () => {
 
   httpRecorder.start();
   let retrievedRecordData = false;
-  httpRecorder.on("record", async ({ responseBody }) => {
+  httpRecorder.addListener("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello!");
       retrievedRecordData = true;
@@ -378,7 +378,7 @@ test("response with content-encoding: deflate", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ responseBody }) => {
+  httpRecorder.addListener("record", async ({ responseBody }) => {
     try {
       zlib.inflate(Buffer.concat(responseBody), (error, buffer) => {
         try {
@@ -413,7 +413,7 @@ test("response with redirect", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ response }) => {
+  httpRecorder.addListener("record", async ({ response }) => {
     try {
       assert.equal(response.headers.location, "https://example.com");
       flowControl.resolve();
@@ -441,7 +441,7 @@ test("response.read()", async () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ responseBody }) => {
+  httpRecorder.addListener("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello!");
       recordControl.resolve();
@@ -486,7 +486,7 @@ test("https", () => {
   const { port } = server.listen().address();
 
   httpRecorder.start();
-  httpRecorder.on("record", async ({ responseBody }) => {
+  httpRecorder.addListener("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello, World!");
       flowControl.resolve();

--- a/test/record-test.js
+++ b/test/record-test.js
@@ -22,7 +22,7 @@ function getFlowControl() {
 }
 
 test.before.each(() => {
-  httpRecorder.disable();
+  httpRecorder.stop();
   httpRecorder.removeAllListeners();
 });
 
@@ -35,7 +35,7 @@ test("happy path", () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on(
     "record",
     async ({ request, response, requestBody, responseBody }) => {
@@ -102,7 +102,7 @@ test("emits 'record' event", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", flowControl.resolve);
 
   const request = http.request(`http://localhost:${port}`, (response) => {
@@ -123,7 +123,7 @@ test("request.write() with base64 encoding", () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ requestBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
@@ -160,7 +160,7 @@ test("request.write(data, callback)", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ requestBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
@@ -199,7 +199,7 @@ test("request.end(text)", () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ requestBody, responseBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
@@ -234,7 +234,7 @@ test("request.end(callback)", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ requestBody, responseBody }) => {
     try {
       assert.equal(Buffer.concat(requestBody).toString(), "Hello!");
@@ -275,7 +275,7 @@ test("delayed response read", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   let retrievedRecordData = false;
   httpRecorder.on("record", async ({ responseBody }) => {
     try {
@@ -330,7 +330,7 @@ test("response.end(text)", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   let retrievedRecordData = false;
   httpRecorder.on("record", async ({ responseBody }) => {
     try {
@@ -377,7 +377,7 @@ test("response with content-encoding: deflate", () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ responseBody }) => {
     try {
       zlib.inflate(Buffer.concat(responseBody), (error, buffer) => {
@@ -412,7 +412,7 @@ test("response with redirect", () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ response }) => {
     try {
       assert.equal(response.headers.location, "https://example.com");
@@ -440,7 +440,7 @@ test("response.read()", async () => {
   });
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello!");
@@ -485,7 +485,7 @@ test("https", () => {
   );
   const { port } = server.listen().address();
 
-  httpRecorder.enable();
+  httpRecorder.start();
   httpRecorder.on("record", async ({ responseBody }) => {
     try {
       assert.equal(Buffer.concat(responseBody).toString(), "Hello, World!");


### PR DESCRIPTION
### Breaking changes

- rename `.enable()` to `.start()` and `.disable()` to `.stop()` as it works better with a "recorder"
- prefer `.addListener`/`.removeListener` over `.on/off` for distinction from .start/.stop methods and web compat.
